### PR TITLE
add samples from claymore cluster

### DIFF
--- a/resources-roke/helmchart/Chart.yaml
+++ b/resources-roke/helmchart/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+name: nginx
+version: 2.2.2
+appVersion: 0.1.0
+keywords:
+  - nginx
+kubeVersion: ">=1.10.0-0"

--- a/resources-roke/helmchart/templates/nginx-deployment.yaml
+++ b/resources-roke/helmchart/templates/nginx-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: {{ int .Values.replicas }}
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80

--- a/resources-roke/helmchart/values.yaml
+++ b/resources-roke/helmchart/values.yaml
@@ -1,0 +1,1 @@
+replicas: 2

--- a/resources-roke/resource/configmap.yaml
+++ b/resources-roke/resource/configmap.yaml
@@ -1,0 +1,51 @@
+---
+---
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: multins
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap-2222
+  namespace: multins
+data:
+  path: resource
+---
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap-2
+  namespace: default
+data:
+  path: resource
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap-3
+  namespace: default
+data:
+  path: resource
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap-4
+  namespace: default
+data:
+  path: resource
+---
+---
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap-5
+  namespace: default
+data:
+  path: resource
+		

--- a/resources-roke/resource/frontend-deployment.yaml
+++ b/resources-roke/resource/frontend-deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: default
+  labels:
+    app: guestbook
+spec:
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - name: php-redis
+        image: gcr.io/google-samples/gb-frontend:v4
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # Using `GET_HOSTS_FROM=dns` requires your cluster to
+          # provide a dns service. As of Kubernetes 1.3, DNS is a built-in
+          # service launched automatically. However, if the cluster you are using
+          # does not have a built-in DNS service, you can instead
+          # access an environment variable to find the master
+          # service's host. To do so, comment out the 'value: dns' line above, and
+          # uncomment the line below:
+          # value: env
+        ports:
+        - containerPort: 80

--- a/resources-roke/resource/frontend-service.yaml
+++ b/resources-roke/resource/frontend-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: default
+  labels:
+    app: guestbook
+    tier: frontend
+spec:
+  # comment or delete the following line if you want to use a LoadBalancer
+  type: NodePort 
+  # if your cluster supports it, uncomment the following to automatically create
+  # an external load-balanced IP for the frontend service.
+  # type: LoadBalancer
+  ports:
+  - port: 80
+  selector:
+    app: guestbook
+    tier: frontend

--- a/resources-roke/resource/redis-master-deployment.yaml
+++ b/resources-roke/resource/redis-master-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: redis-master
+  namespace: default
+  labels:
+    app: redis
+spec:
+  selector:
+    matchLabels:
+      app: redis
+      role: master
+      tier: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: master
+        tier: backend
+    spec:
+      containers:
+      - name: master
+        image: k8s.gcr.io/redis:e2e  # or just image: redis
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 6379

--- a/resources-roke/resource/redis-master-service.yaml
+++ b/resources-roke/resource/redis-master-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  namespace: default
+  labels:
+    app: redis
+    role: master
+    tier: backend
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis
+    role: master
+    tier: backend

--- a/resources-roke/resource/redis-slave-deployment.yaml
+++ b/resources-roke/resource/redis-slave-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: redis-slave
+  namespace: default
+  labels:
+    app: redis
+spec:
+  selector:
+    matchLabels:
+      app: redis
+      role: slave
+      tier: backend
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: slave
+        tier: backend
+    spec:
+      containers:
+      - name: slave
+        image: gcr.io/google_samples/gb-redisslave:v3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # Using `GET_HOSTS_FROM=dns` requires your cluster to
+          # provide a dns service. As of Kubernetes 1.3, DNS is a built-in
+          # service launched automatically. However, if the cluster you are using
+          # does not have a built-in DNS service, you can instead
+          # access an environment variable to find the master
+          # service's host. To do so, comment out the 'value: dns' line above, and
+          # uncomment the line below:
+          # value: env
+        ports:
+        - containerPort: 6379

--- a/resources-roke/resource/redis-slave-service.yaml
+++ b/resources-roke/resource/redis-slave-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-slave
+  namespace: default
+  labels:
+    app: redis
+    role: slave
+    tier: backend
+spec:
+  ports:
+  - port: 6379
+  selector:
+    app: redis
+    role: slave
+    tier: backend

--- a/sample-demo-saude-digital/application.yaml
+++ b/sample-demo-saude-digital/application.yaml
@@ -1,0 +1,18 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: demo-saude-digital
+  namespace: demo-saude-digital
+  labels:
+    app: demo-saude-digital
+spec:
+  componentKinds:
+    - group: apps.open-cluster-management.io
+      kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - demo-saude-digital

--- a/sample-demo-saude-digital/channel.yaml
+++ b/sample-demo-saude-digital/channel.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: github-redhat-sa-brazil-demo-summitgov-cy20
+  namespace: demo-saude-digital-repos
+spec:
+  pathname: 'https://github.com/redhat-sa-brazil/demo-summitgov-cy20.git'
+  type: GitHub

--- a/sample-demo-saude-digital/channel.yaml
+++ b/sample-demo-saude-digital/channel.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: demo-saude-digital-repos
 spec:
   pathname: 'https://github.com/redhat-sa-brazil/demo-summitgov-cy20.git'
-  type: GitHub
+  type: Git

--- a/sample-demo-saude-digital/kustomization.yaml
+++ b/sample-demo-saude-digital/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- namespace.yaml
+- namespace-ch.yaml
+- channel.yaml
+- placementrule.yaml
+- subscription.yaml
+- application.yaml

--- a/sample-demo-saude-digital/namespace-ch.yaml
+++ b/sample-demo-saude-digital/namespace-ch.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo-saude-digital-repos

--- a/sample-demo-saude-digital/namespace.yaml
+++ b/sample-demo-saude-digital/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo-saude-digital

--- a/sample-demo-saude-digital/placementrule.yaml
+++ b/sample-demo-saude-digital/placementrule.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: demo-saude-digital
+  namespace: demo-saude-digital
+  labels:
+    app: demo-saude-digital
+spec:
+  clusterReplicas: 2
+  clusterSelector:
+    matchLabels:
+      environment: Dev

--- a/sample-demo-saude-digital/subscription.yaml
+++ b/sample-demo-saude-digital/subscription.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: demo-saude-digital
+  namespace: demo-saude-digital
+  labels:
+    app: demo-saude-digital
+spec:
+  channel: demo-saude-digital-repos/github-redhat-sa-brazil-demo-summitgov-cy20
+  placement:
+    placementRef:
+      name: demo-saude-digital
+      kind: PlacementRule

--- a/sample-git-demo-app/application.yaml
+++ b/sample-git-demo-app/application.yaml
@@ -1,0 +1,16 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: git-demo-app
+  namespace: demo-ns-helm-git
+spec:
+  componentKinds:
+    - group: apps.open-cluster-management.io
+      kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - git-demo-app

--- a/sample-git-demo-app/channel.yaml
+++ b/sample-git-demo-app/channel.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: git-helm-ch
+  namespace: demo-ns-helm-git-ch
+spec:
+  pathname: 'https://github.com/rokej/testrepo.git'
+  type: GitHub

--- a/sample-git-demo-app/channel.yaml
+++ b/sample-git-demo-app/channel.yaml
@@ -4,5 +4,5 @@ metadata:
   name: git-helm-ch
   namespace: demo-ns-helm-git-ch
 spec:
-  pathname: 'https://github.com/rokej/testrepo.git'
-  type: GitHub
+  pathname: 'https://github.com/fxiang1/app-samples.git'
+  type: Git

--- a/sample-git-demo-app/kustomization.yaml
+++ b/sample-git-demo-app/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- namespace.yaml
+- namespace-ch.yaml
+- channel.yaml
+- placementrule.yaml
+- subscription.yaml
+- application.yaml

--- a/sample-git-demo-app/namespace-ch.yaml
+++ b/sample-git-demo-app/namespace-ch.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo-ns-helm-git-ch

--- a/sample-git-demo-app/namespace.yaml
+++ b/sample-git-demo-app/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo-ns-helm-git

--- a/sample-git-demo-app/placementrule.yaml
+++ b/sample-git-demo-app/placementrule.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: dev-clusters
+  namespace: demo-ns-helm-git
+spec:
+  clusterLabels:
+    matchLabels:
+      environment: Dev

--- a/sample-git-demo-app/subscription.yaml
+++ b/sample-git-demo-app/subscription.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: demo-subscription
+  namespace: demo-ns-helm-git
+  labels:
+    app: git-demo-app
+spec:
+  channel: demo-ns-helm-git-ch/git-helm-ch
+  placement:
+    placementRef:
+      name: dev-clusters

--- a/sample-git-demo-app/subscription.yaml
+++ b/sample-git-demo-app/subscription.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: demo-ns-helm-git
   labels:
     app: git-demo-app
+  annotations:
+    apps.open-cluster-management.io/github-path: resources-roke/helmchart
+    apps.open-cluster-management.io/github-branch: master
 spec:
   channel: demo-ns-helm-git-ch/git-helm-ch
   placement:

--- a/sample-git-sub-app/application.yaml
+++ b/sample-git-sub-app/application.yaml
@@ -1,0 +1,13 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: git-sub-app
+  namespace: git-sub-ns-helm
+spec:
+  componentKinds:
+    - group: apps.open-cluster-management.io
+      kind: Subscription
+  descriptor: {}
+  selector:
+    matchLabels:
+      name: git-sub

--- a/sample-git-sub-app/channel.yaml
+++ b/sample-git-sub-app/channel.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: git-helm
+  namespace: ch-git-helm
+  labels:
+    name: git-sub
+spec:
+  pathname: 'https://github.com/open-cluster-management/multicloud-operators-subscription'
+  type: Git

--- a/sample-git-sub-app/kustomization.yaml
+++ b/sample-git-sub-app/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- namespace.yaml
+- namespace-ch.yaml
+- channel.yaml
+- placementrule.yaml
+- subscription.yaml
+- application.yaml

--- a/sample-git-sub-app/namespace-ch.yaml
+++ b/sample-git-sub-app/namespace-ch.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ch-git-helm

--- a/sample-git-sub-app/namespace.yaml
+++ b/sample-git-sub-app/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: git-sub-ns-helm

--- a/sample-git-sub-app/placementrule.yaml
+++ b/sample-git-sub-app/placementrule.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: towhichcluster
+  namespace: git-sub-ns-helm
+  labels:
+    name: git-sub
+spec:
+  clusterLabels:
+    matchLabels:
+      environment: Dev
+  clusterReplicas: 1

--- a/sample-git-sub-app/subscription.yaml
+++ b/sample-git-sub-app/subscription.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: git-helm-sub
+  namespace: git-sub-ns-helm
+  labels:
+    name: git-sub
+spec:
+  channel: ch-git-helm/git-helm
+  placement:
+    placementRef:
+      name: towhichcluster
+      kind: PlacementRule

--- a/sample-guestbook-app-default-ns/application.yaml
+++ b/sample-guestbook-app-default-ns/application.yaml
@@ -1,0 +1,16 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: guestbook-app
+  namespace: default
+spec:
+  componentKinds:
+    - group: apps.open-cluster-management.io
+      kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - guestbook-app

--- a/sample-guestbook-app-default-ns/channel.yaml
+++ b/sample-guestbook-app-default-ns/channel.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: gbapp-ch
 spec:
   pathname: 'https://github.com/kubernetes/examples.git'
-  type: GitHub
+  type: Git

--- a/sample-guestbook-app-default-ns/channel.yaml
+++ b/sample-guestbook-app-default-ns/channel.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: guestbook-app-latest
+  namespace: gbapp-ch
+spec:
+  pathname: 'https://github.com/kubernetes/examples.git'
+  type: GitHub

--- a/sample-guestbook-app-default-ns/kustomization.yaml
+++ b/sample-guestbook-app-default-ns/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- namespace.yaml
+- channel.yaml
+- placementrule.yaml
+- subscription.yaml
+- application.yaml

--- a/sample-guestbook-app-default-ns/namespace.yaml
+++ b/sample-guestbook-app-default-ns/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gbapp-ch

--- a/sample-guestbook-app-default-ns/placementrule.yaml
+++ b/sample-guestbook-app-default-ns/placementrule.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: dev-clusters
+  namespace: default
+spec:
+  clusterLabels:
+    matchLabels:
+      environment: Dev
+  clusterReplicas: 3

--- a/sample-guestbook-app-default-ns/subscription.yaml
+++ b/sample-guestbook-app-default-ns/subscription.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: guestbook-app
+  namespace: default
+  labels:
+    app: guestbook-app
+spec:
+  channel: gbapp-ch/guestbook-app-latest
+  packageFilter:
+    filterRef:
+      name: resource-filter-configmap
+  placement:
+    placementRef:
+      name: dev-clusters
+      kind: PlacementRule

--- a/sample-guestbook-app-gb-git-ns/application.yaml
+++ b/sample-guestbook-app-gb-git-ns/application.yaml
@@ -1,0 +1,16 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: guestbook-app
+  namespace: app-guestbook-git-ns
+spec:
+  componentKinds:
+    - group: apps.open-cluster-management.io
+      kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - guestbook-app

--- a/sample-guestbook-app-gb-git-ns/channel.yaml
+++ b/sample-guestbook-app-gb-git-ns/channel.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: guestbook-app-latest
+  namespace: deploy-git
+spec:
+  pathname: 'https://github.com/open-cluster-management/deploy.git'
+  type: GitHub

--- a/sample-guestbook-app-gb-git-ns/channel.yaml
+++ b/sample-guestbook-app-gb-git-ns/channel.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: deploy-git
 spec:
   pathname: 'https://github.com/open-cluster-management/deploy.git'
-  type: GitHub
+  type: Git

--- a/sample-guestbook-app-gb-git-ns/kustomization.yaml
+++ b/sample-guestbook-app-gb-git-ns/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- namespace.yaml
+- namespace-ch.yaml
+- channel.yaml
+- placementrule.yaml
+- subscription.yaml
+- application.yaml

--- a/sample-guestbook-app-gb-git-ns/namespace-ch.yaml
+++ b/sample-guestbook-app-gb-git-ns/namespace-ch.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: deploy-git

--- a/sample-guestbook-app-gb-git-ns/namespace.yaml
+++ b/sample-guestbook-app-gb-git-ns/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app-guestbook-git-ns

--- a/sample-guestbook-app-gb-git-ns/placementrule.yaml
+++ b/sample-guestbook-app-gb-git-ns/placementrule.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: dev-clusters
+  namespace: app-guestbook-git-ns
+spec:
+  clusterLabels:
+    matchLabels:
+      environment: Dev
+  clusterReplicas: 4

--- a/sample-guestbook-app-gb-git-ns/subscription.yaml
+++ b/sample-guestbook-app-gb-git-ns/subscription.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: guestbook-app
+  namespace: app-guestbook-git-ns
+  labels:
+    app: guestbook-app
+spec:
+  channel: deploy-git/guestbook-app-latest
+  placement:
+    placementRef:
+      name: dev-clusters
+      kind: PlacementRule

--- a/sample-guestbook-app-ocm-ns/application.yaml
+++ b/sample-guestbook-app-ocm-ns/application.yaml
@@ -1,0 +1,16 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: guestbook-app
+  namespace: open-cluster-management
+spec:
+  componentKinds:
+    - group: apps.open-cluster-management.io
+      kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - guestbook-app

--- a/sample-guestbook-app-ocm-ns/channel.yaml
+++ b/sample-guestbook-app-ocm-ns/channel.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: git-helm-ch
+  namespace: gb-app-latest-ns
+spec:
+  pathname: 'https://github.com/rokej/testrepo.git'
+  type: GitHub

--- a/sample-guestbook-app-ocm-ns/channel.yaml
+++ b/sample-guestbook-app-ocm-ns/channel.yaml
@@ -4,5 +4,5 @@ metadata:
   name: git-helm-ch
   namespace: gb-app-latest-ns
 spec:
-  pathname: 'https://github.com/rokej/testrepo.git'
-  type: GitHub
+  pathname: 'https://github.com/fxiang1/app-samples.git'
+  type: Git

--- a/sample-guestbook-app-ocm-ns/kustomization.yaml
+++ b/sample-guestbook-app-ocm-ns/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- namespace.yaml
+- namespace-ch.yaml
+- channel.yaml
+- placementrule.yaml
+- subscription.yaml
+- application.yaml

--- a/sample-guestbook-app-ocm-ns/namespace-ch.yaml
+++ b/sample-guestbook-app-ocm-ns/namespace-ch.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gb-app-latest-ns

--- a/sample-guestbook-app-ocm-ns/namespace.yaml
+++ b/sample-guestbook-app-ocm-ns/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: open-cluster-management

--- a/sample-guestbook-app-ocm-ns/placementrule.yaml
+++ b/sample-guestbook-app-ocm-ns/placementrule.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: dev-clusters
+  namespace: open-cluster-management
+spec:
+  clusterLabels:
+    matchLabels:
+      environment: Dev
+  clusterReplicas: 0

--- a/sample-guestbook-app-ocm-ns/subscription.yaml
+++ b/sample-guestbook-app-ocm-ns/subscription.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: open-cluster-management
   labels:
     app: guestbook-app
+  aannotations:
+    apps.open-cluster-management.io/github-path: resources-roke/helmchart
+    apps.open-cluster-management.io/github-branch: master
 spec:
   channel: gb-app-latest-ns/git-helm-ch
   packageFilter:

--- a/sample-guestbook-app-ocm-ns/subscription.yaml
+++ b/sample-guestbook-app-ocm-ns/subscription.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: guestbook-app
+  namespace: open-cluster-management
+  labels:
+    app: guestbook-app
+spec:
+  channel: gb-app-latest-ns/git-helm-ch
+  packageFilter:
+    filterRef:
+      name: resource-filter-configmap
+  placement:
+    placementRef:
+      name: dev-clusters
+      kind: PlacementRule

--- a/sample-nginx-blue/application.yaml
+++ b/sample-nginx-blue/application.yaml
@@ -1,0 +1,16 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: nginx-blue
+  namespace: nginx-blue
+spec:
+  componentKinds:
+    - group: app.ibm.com/v1alpha1
+      kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - nginx-deployment

--- a/sample-nginx-blue/channel-gitops.yaml
+++ b/sample-nginx-blue/channel-gitops.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: gitops
+  namespace: demo
+spec:
+  pathname: 'https://github.com/open-cluster-management/demo-subscription-gitops.git'
+  type: GitHub

--- a/sample-nginx-blue/channel-gitops.yaml
+++ b/sample-nginx-blue/channel-gitops.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: demo
 spec:
   pathname: 'https://github.com/open-cluster-management/demo-subscription-gitops.git'
-  type: GitHub
+  type: Git

--- a/sample-nginx-blue/channel-mortgage-ch.yaml
+++ b/sample-nginx-blue/channel-mortgage-ch.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: mortgage-ch
 spec:
   pathname: 'https://github.com/fxiang1/mortgage.git'
-  type: GitHub
+  type: Git

--- a/sample-nginx-blue/channel-mortgage-ch.yaml
+++ b/sample-nginx-blue/channel-mortgage-ch.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: mortgage-channel
+  namespace: mortgage-ch
+spec:
+  pathname: 'https://github.com/fxiang1/mortgage.git'
+  type: GitHub

--- a/sample-nginx-blue/channel-mortgagecm-ch.yaml
+++ b/sample-nginx-blue/channel-mortgagecm-ch.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: mortgagecm-channel
+  namespace: mortgagecm-ch
+spec:
+  pathname: 'https://github.com/fxiang1/mortgage.git'
+  type: GitHub

--- a/sample-nginx-blue/channel-mortgagecm-ch.yaml
+++ b/sample-nginx-blue/channel-mortgagecm-ch.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: mortgagecm-ch
 spec:
   pathname: 'https://github.com/fxiang1/mortgage.git'
-  type: GitHub
+  type: Git

--- a/sample-nginx-blue/kustomization.yaml
+++ b/sample-nginx-blue/kustomization.yaml
@@ -1,0 +1,14 @@
+resources:
+- namespace.yaml
+- namespace-gitops-ch.yaml
+- namespace-mortgagecm-ch.yaml
+- namespace-mortgage-ch.yaml
+- channel-gitops.yaml
+- channel-mortgagecm-ch.yaml
+- channel-mortgage-ch.yaml
+- placementrule.yaml
+- subscription-gitops-1.yaml
+- subscription-gitops-2.yaml
+- subscription-mortgagecm-ch.yaml
+- subscription-mortgage-ch.yaml
+- application.yaml

--- a/sample-nginx-blue/namespace-gitops-ch.yaml
+++ b/sample-nginx-blue/namespace-gitops-ch.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo

--- a/sample-nginx-blue/namespace-mortgage-ch.yaml
+++ b/sample-nginx-blue/namespace-mortgage-ch.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mortgage-ch

--- a/sample-nginx-blue/namespace-mortgagecm-ch.yaml
+++ b/sample-nginx-blue/namespace-mortgagecm-ch.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mortgagecm-ch

--- a/sample-nginx-blue/namespace.yaml
+++ b/sample-nginx-blue/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-blue

--- a/sample-nginx-blue/placementrule.yaml
+++ b/sample-nginx-blue/placementrule.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+labels:
+  app: nginx-deployment
+metadata:
+  name: nginx-deployment
+  namespace: nginx-blue
+spec:
+  clusterSelector:
+    matchLabels:
+      environment: Dev

--- a/sample-nginx-blue/subscription-gitops-1.yaml
+++ b/sample-nginx-blue/subscription-gitops-1.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: ingress-nginx-subscription-blue
+  namespace: nginx-blue
+  labels:
+    app: nginx-deployment
+spec:
+  channel: demo/gitops
+  placement:
+    placementRef:
+      name: nginx-deployment
+      kind: PlacementRule

--- a/sample-nginx-blue/subscription-gitops-2.yaml
+++ b/sample-nginx-blue/subscription-gitops-2.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: blue-nginx-subscription
+  namespace: nginx-blue
+  labels:
+    app: nginx-deployment
+spec:
+  channel: demo/gitops
+  placement:
+    placementRef:
+      name: nginx-deployment
+      kind: PlacementRule

--- a/sample-nginx-blue/subscription-mortgage-ch.yaml
+++ b/sample-nginx-blue/subscription-mortgage-ch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: nginx-subscription-blue-3
+  namespace: nginx-blue
+  labels:
+    app: nginx-deployment
+spec:
+  channel: mortgage-ch/mortgage-channel
+  placement:
+    placementRef:
+      name: nginx-deployment
+      kind: PlacementRule

--- a/sample-nginx-blue/subscription-mortgagecm-ch.yaml
+++ b/sample-nginx-blue/subscription-mortgagecm-ch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: nginx-subscription-blue-4
+  namespace: nginx-blue
+  labels:
+    app: nginx-deployment
+spec:
+  channel: mortgagecm-ch/mortgagecm-channel
+  placement:
+    placementRef:
+      name: nginx-deployment
+      kind: PlacementRule

--- a/sample-nginx-green/application.yaml
+++ b/sample-nginx-green/application.yaml
@@ -1,0 +1,16 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: nginx-green
+  namespace: nginx-green
+spec:
+  componentKinds:
+    - group: app.ibm.com/v1alpha1
+      kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - nginx-deployment

--- a/sample-nginx-green/channel.yaml
+++ b/sample-nginx-green/channel.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: gitops
+  namespace: demo
+spec:
+  pathname: 'https://github.com/open-cluster-management/demo-subscription-gitops.git'
+  type: GitHub

--- a/sample-nginx-green/channel.yaml
+++ b/sample-nginx-green/channel.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: demo
 spec:
   pathname: 'https://github.com/open-cluster-management/demo-subscription-gitops.git'
-  type: GitHub
+  type: Git

--- a/sample-nginx-green/kustomization.yaml
+++ b/sample-nginx-green/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+- namespace.yaml
+- namespace-ch.yaml
+- channel.yaml
+- placementrule.yaml
+- subscription-1.yaml
+- subscription-2.yaml
+- application.yaml

--- a/sample-nginx-green/namespace-ch.yaml
+++ b/sample-nginx-green/namespace-ch.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo

--- a/sample-nginx-green/namespace.yaml
+++ b/sample-nginx-green/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-green

--- a/sample-nginx-green/placementrule.yaml
+++ b/sample-nginx-green/placementrule.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: nginx-deployment
+  namespace: nginx-green
+  labels:
+    app: nginx-deployment
+spec:
+  clusterSelector:
+    matchLabels:
+      environment: Dev

--- a/sample-nginx-green/subscription-1.yaml
+++ b/sample-nginx-green/subscription-1.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: green-nginx-subscription
+  namespace: nginx-green
+  labels:
+    app: nginx-deployment
+spec:
+  channel: demo/gitops
+  placement:
+    placementRef:
+      name: nginx-deployment
+      kind: PlacementRule

--- a/sample-nginx-green/subscription-2.yaml
+++ b/sample-nginx-green/subscription-2.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: ingress-nginx-subscription-green
+  namespace: nginx-green
+  labels:
+    app: nginx-deployment
+spec:
+  channel: demo/gitops
+  placement:
+    placementRef:
+      name: nginx-deployment
+      kind: PlacementRule

--- a/sample-nginx-placement/application.yaml
+++ b/sample-nginx-placement/application.yaml
@@ -1,0 +1,16 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: nginx-placement
+  namespace: nginx
+spec:
+  componentKinds:
+    - group: app.ibm.com/v1alpha1
+      kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - nginx-placement

--- a/sample-nginx-placement/channel.yaml
+++ b/sample-nginx-placement/channel.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: gitops
+  namespace: demo
+spec:
+  pathname: 'https://github.com/open-cluster-management/demo-subscription-gitops.git'
+  type: GitHub

--- a/sample-nginx-placement/channel.yaml
+++ b/sample-nginx-placement/channel.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: demo
 spec:
   pathname: 'https://github.com/open-cluster-management/demo-subscription-gitops.git'
-  type: GitHub
+  type: Git

--- a/sample-nginx-placement/kustomization.yaml
+++ b/sample-nginx-placement/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- namespace.yaml
+- namespace-ch.yaml
+- channel.yaml
+- placementrule.yaml
+- subscription.yaml
+- application.yaml

--- a/sample-nginx-placement/namespace-ch.yaml
+++ b/sample-nginx-placement/namespace-ch.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo

--- a/sample-nginx-placement/namespace.yaml
+++ b/sample-nginx-placement/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx

--- a/sample-nginx-placement/placementrule.yaml
+++ b/sample-nginx-placement/placementrule.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: nginx-placement
+  namespace: nginx
+  labels:
+    app: nginx-placement
+spec:
+  clusterReplicas: 1
+  clusterSelector:
+    matchLabels:
+      environment: Dev

--- a/sample-nginx-placement/subscription.yaml
+++ b/sample-nginx-placement/subscription.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: placement-nginx-subscription
+  namespace: nginx
+  labels:
+    app: nginx-placement
+spec:
+  channel: demo/gitops
+  placement:
+    placementRef:
+      name: nginx-placement
+      kind: PlacementRule


### PR DESCRIPTION
Added 9 application samples from claymore cluster:
- demo-saude-digital
- git-demo-app
- git-sub-app
- guestbook-app (3 from diff namespaces)
- nginx-blue
- nginx-green
- nginx-placement